### PR TITLE
docs: fixed the LICENSE URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ While we don't require a specific pull request format, we kindly ask our contrib
 
 # License 👮
 
-SyllabusX is Licensed under the <a href="./LICENSE.md">GPL License</a>. Please go through the License at least once before contributing.
+SyllabusX is Licensed under the <a href="./LICENSE">GPL License</a>. Please go through the License at least once before contributing.
 
 # Contributors
 


### PR DESCRIPTION
Minor documentation fix: The LICENSE URL in README.md was "./LICENSE.md", which doesn't exist. Changed it to "./LICENSE".
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] This change requires a documentation update